### PR TITLE
fix: Move taffydb from dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,28 @@
 {
   "name": "@parse/minami",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@parse/minami",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "taffydb": "2.7.3"
+      }
+    },
+    "node_modules/taffydb": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
+      "integrity": "sha1-KtNxaWKUmPylvIQkMJbTzeDsOjQ="
+    }
+  },
   "dependencies": {
     "taffydb": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
-      "integrity": "sha1-KtNxaWKUmPylvIQkMJbTzeDsOjQ=",
-      "dev": true
+      "integrity": "sha1-KtNxaWKUmPylvIQkMJbTzeDsOjQ="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,13 +10,12 @@
     "type": "git",
     "url": "https://github.com/parse-community/minami.git"
   },
-  "author": "Nijiko Yonskai <nijikokun@gmail.com>",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/parse-community/minami/issues"
   },
   "homepage": "https://github.com/parse-community/minami",
-  "devDependencies": {
-    "taffydb": "^2.7.3"
+  "dependencies": {
+    "taffydb": "2.7.3"
   }
 }


### PR DESCRIPTION
Documentation generation is currently broken.

```
FATAL: Unable to load template: Cannot find module 'taffydb'
Require stack:
- /Users/dplewis/Documents/GitHub/Parse-SDK-JS/node_modules/@parse/minami/publish.js
- /Users/dplewis/Documents/GitHub/Parse-SDK-JS/node_modules/jsdoc/cli.js
- /Users/dplewis/Documents/GitHub/Parse-SDK-JS/node_modules/jsdoc/jsdoc.js
```